### PR TITLE
WDP190801-13

### DIFF
--- a/src/partials/30_section-features.html
+++ b/src/partials/30_section-features.html
@@ -1,7 +1,7 @@
 <div class="section--features">
   <div class="container">
     <div class="row">
-      <div class="col">
+      <div class="col-lg-3 col-md-6 col-sm-6 col-6">
         <div class="feature-box active">
           <div class="icon"><i class="fas fa-truck"></i></div>
           <div class="content">
@@ -10,7 +10,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-md-6 col-sm-6 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-headphones"></i></div>
           <div class="content">
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-md-6 col-sm-6 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-reply-all"></i></div>
           <div class="content">
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-md-6 col-sm-6 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-bullhorn"></i></div>
           <div class="content">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -2,6 +2,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  min-height: 142px;
 
   .icon {
     transform: translateY(-50%);


### PR DESCRIPTION
**Problem**
Karty korzyści w trybach tablet i mobile mają być w dwóch rzędach po dwa elementy w każdym. Elementy obok siebie nie powinny różnić się wysokością.
**Rozwiązanie**
Dodałam klasy `<div class="col-lg-3 col-md-6 col-sm-6 col-6>` odpowiadające za układ elementów w rzędzie w zależności od rozdzielczości urządzenia. Dodałam minimalną wysokość do klasy .feature-box co zapobiega różnicom w wysokości kart po zmianie rozdzielczości.