### PR TITLE
WDP190801-14

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -50,7 +50,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -78,7 +78,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -106,7 +106,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -134,7 +134,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -162,7 +162,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -190,7 +190,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>
@@ -218,7 +218,7 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-lg-3 col-md col-xs">
         <div class="product-box">
           <div class="photo">
             <div class="sale">sale</div>

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -80,3 +80,34 @@
     align-items: center;
   }
 }
+
+//tablet portrait
+@media (max-width: 991px) {
+  .col-md {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}
+
+//tablet landscape
+@media (max-height: 768px) {
+  .col-md {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%;
+  }
+}
+
+//mobile portrait
+@media (max-width: 425px) {
+  .col-xs {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+
+@media (max-height: 425px) {
+  .col-xs {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -98,16 +98,9 @@
 }
 
 //mobile portrait
-@media (max-width: 425px) {
+@media (max-width: 567px), (max-height: 567px) {
   .col-xs {
     flex: 0 0 100%;
     max-width: 100%;
-  }
-}
-
-@media (max-height: 425px) {
-  .col-xs {
-    flex: 0 0 50%;
-    max-width: 50%;
   }
 }


### PR DESCRIPTION
**Problem**
Na tabletach elementy w sekcji "New furniture" mają być po 2-3 w rzędzie a na mobile 2 w rzędzie dla 568px, a na mniejszych w jednym.
**Rozwiązanie**
Dodałam klasy odpowiadające za układ elementów w rzędzie w zależności od rozdzielczości urządzenia. Następnie dodałam ostylowanie do klas w zależności od tego czy jest to: tablet w układzie portrait, tablet landscape, telefon o rozdzielczości maksymalnie 567px.