### PR TITLE
WDP190801-16

### DIFF
--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -54,7 +54,7 @@
     <div class="container">
       <div class="row align-items-center">
         <div class="col-lg-4 col-md-12"></div>
-        <div class="col-lg-4 col-md-6 copyright text-center">
+        <div class="col-lg-4 col-md-6 copyright text-left text-lg-center">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
         <div class="col-lg-4 col-md-6 socialmedia text-right">

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -2,7 +2,7 @@
   <div class="footer-menu">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col col-xs">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -13,7 +13,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col col-xs">
           <div class="menu-wrapper">
             <h6>My account</h6>
             <ul>
@@ -24,7 +24,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col col-xs">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col col-xs">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -53,11 +53,11 @@
   <div class="bottom-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col"></div>
-        <div class="col copyright text-center">
+        <div class="col-lg-4 col-md-12"></div>
+        <div class="col-lg-4 col-md-6 copyright text-center">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col socialmedia text-right">
+        <div class="col-lg-4 col-md-6 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -78,3 +78,9 @@ footer {
     }
   }
 }
+
+@media (max-width: 768px) {
+  .copyright {
+    text-align: left !important;
+  }
+}

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -79,12 +79,6 @@ footer {
   }
 }
 
-@media (max-width: 768px) {
-  .copyright {
-    text-align: left !important;
-  }
-}
-
 @media (max-width: 425px) {
   .col-xs {
     flex: 0 0 50%;

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -84,3 +84,15 @@ footer {
     text-align: left !important;
   }
 }
+
+@media (max-width: 425px) {
+  .col-xs {
+    flex: 0 0 50%;
+    max-width: 50%;
+    position: relative;
+    img {
+      position: absolute;
+      right: 20px;
+    }
+  }
+}


### PR DESCRIPTION
**Problem**
W górnej partii stopki na małych ekranach mają być po dwie sekcje na szerokość. W dolnym pasku na tablecie copyright ma być od lewej, a socjalki od prawej. Pusty div gdzie może być coś dodane ma być na całą szerokość powyżej copyright i socjalek.
**Rozwiązanie**
Dodałam klasę col-xs i ostylowałam tak że na małych ekranach są dwie sekcje na szerokość. Dodałam do obrazka w sekcji orders position: absolute żeby był cały widoczny. Dodałam klasę i style do pustego diva żeby zajmował całą szerokość na tabletach. Dodałam text-align: left !important do klacy copyright.